### PR TITLE
Task 036

### DIFF
--- a/src/main/java/acme/entities/systemconfiguration/SystemConfiguration.java
+++ b/src/main/java/acme/entities/systemconfiguration/SystemConfiguration.java
@@ -1,0 +1,43 @@
+package acme.entities.systemconfiguration;
+
+import javax.persistence.Entity;
+import javax.validation.constraints.NotNull;
+
+import acme.framework.entities.AbstractEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class SystemConfiguration extends AbstractEntity {
+
+	// Serialisation identifier -----------------------------------------------
+
+	protected static final long		serialVersionUID	= 1L;
+
+	// Attributes -------------------------------------------------------------
+
+	@NotNull
+	protected String				currency;
+	
+	@NotNull
+	protected String 				acceptedCurrencies;
+
+	@NotNull
+	protected String				strongSpamTerms;
+
+	@NotNull
+	protected Double				strongSpamThreshold;
+	
+	@NotNull
+	protected String				weakSpamTerms;
+	
+	@NotNull
+	protected Double				weakSpamThreshold;
+
+	// Derived attributes -----------------------------------------------------
+
+	// Relationships ----------------------------------------------------------
+
+}

--- a/src/main/webapp/WEB-INF/resources/initial-data/system-configuration.csv
+++ b/src/main/webapp/WEB-INF/resources/initial-data/system-configuration.csv
@@ -1,0 +1,2 @@
+key,currency,accepted-currencies,strong-spam-terms,strong-spam-threshold,weak-spam-terms,weak-spam-threshold
+system-configuration-default,EUR,"EUR,USD,GBP","sex,hard core,viagra,cialis,sexo,duro,viagra,cialis",0.10,"sexy,nigeria,you've won,one million,has ganado,un millon",0.25


### PR DESCRIPTION
The lists of strings that we were asked to implement are currently represented by means of a comma-separated single string. For instance, the list of currencies is represented like this:

```java
@NotNull
protected String acceptedCurrencies; // represented as "EUR,USD,GBP" in the populate file
```

I have considered creating a `@ManyToOne` relationship, but that would involve creating entities for each one of the datatypes that we want to store as a collection (Currency, SpamTerm), also creating a `@OneToMany` (but the Strings are not entities as far as I am concerned so it would not be possible) and also an `@ElementCollection`, which is also a class from the `javax.persistence` package but didn't succeed either. If this is not correct, I will ask on friday.

---
Closes #63 
